### PR TITLE
Add functionality to allow users to specify a prefix for mongo collections

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -87,7 +87,14 @@ The configuration options are:
   to use the request host name.
 - +:logger+ -- The logger to use. Under Rails, defaults to use the Rails
   logger.  Will use +Rack::Logger+ if available.
-- +:collection_prefix+ --  Prefix to use in every mongo collection created by server models. By default is oauth2.
+- +:collection_prefix+ -- Sets a prefix for every mongo collection created
+  by the Rack::Oauth2::Server models. By default is oauth2.
+
+If you only intend to use the UI authorization flow, you don't need to worry
+about the authenticator. If you want to allow client applications to create
+access tokens by passing the end-user's username/password, then you need an
+authenticator. This feature is necessary for some client applications, and
+quite handy during development/testing.
 
 The authenticator is a block that receives either two or four parameters.  The
 first two are username and password. The other two are the client identifier

--- a/README.rdoc
+++ b/README.rdoc
@@ -87,12 +87,7 @@ The configuration options are:
   to use the request host name.
 - +:logger+ -- The logger to use. Under Rails, defaults to use the Rails
   logger.  Will use +Rack::Logger+ if available.
-
-If you only intend to use the UI authorization flow, you don't need to worry
-about the authenticator. If you want to allow client applications to create
-access tokens by passing the end-user's username/password, then you need an
-authenticator. This feature is necessary for some client applications, and
-quite handy during development/testing.
+- +:collection_prefix+ --  Prefix to use in every mongo collection created by server models. By default is oauth2.
 
 The authenticator is a block that receives either two or four parameters.  The
 first two are username and password. The other two are the client identifier

--- a/bin/oauth2-server
+++ b/bin/oauth2-server
@@ -14,10 +14,19 @@ if (i = ARGV.index("--db")) && ARGV[i+1]
   Server.options.database = db
   ARGV[i,2] = []
 end
+
 if (i = ARGV.index("--port") || ARGV.index("-p")) && ARGV[i+1]
   port = ARGV[i + 1].to_i
   ARGV[i,2] = []
 end
+
+
+if (i = ARGV.index("--collection-prefix") || ARGV.index("-c")) && ARGV[i+1]
+  prefix = ARGV[i + 1]
+  Server.options.collection_prefix = prefix
+  ARGV[i,2] = []
+end
+
 
 
 case ARGV[0]
@@ -198,6 +207,7 @@ Commands:
 Options:
   --db database   Database name or connection URL
   --port number   Port to run admin server, detault is 8080
+  --collection-prefix Mongo collection prefix to use by oauth models
   TEXT
   exit -1
 

--- a/lib/rack/oauth2/models/access_grant.rb
+++ b/lib/rack/oauth2/models/access_grant.rb
@@ -25,7 +25,8 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.access_grants"]
+            prefix = Server.options[:collection_prefix]
+            Server.database["#{prefix}.access_grants"]
           end
         end
 

--- a/lib/rack/oauth2/models/access_token.rb
+++ b/lib/rack/oauth2/models/access_token.rb
@@ -77,7 +77,8 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.access_tokens"]
+            prefix = Server.options[:collection_prefix]
+            Server.database["#{prefix}.access_tokens"]
           end
         end
 

--- a/lib/rack/oauth2/models/auth_request.rb
+++ b/lib/rack/oauth2/models/auth_request.rb
@@ -28,7 +28,8 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.auth_requests"]
+            prefix = Server.options[:collection_prefix]
+            Server.database["#{prefix}.auth_requests"]
           end
         end
 

--- a/lib/rack/oauth2/models/client.rb
+++ b/lib/rack/oauth2/models/client.rb
@@ -66,7 +66,8 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.clients"]
+            prefix = Server.options[:collection_prefix]
+            Server.database["#{prefix}.clients"]
           end
         end
 

--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -142,6 +142,7 @@ module Rack
       #   Defaults to use the request host name.
       # - :logger -- The logger to use. Under Rails, defaults to use the Rails
       #   logger.  Will use Rack::Logger if available.
+      # - :collection_prefix -- Sets mongo db collection prefix
       #
       # Authenticator is a block that receives either two or four parameters.
       # The first two are username and password. The other two are the client
@@ -153,7 +154,7 @@ module Rack
       #   end
       Options = Struct.new(:access_token_path, :authenticator, :authorization_types,
         :authorize_path, :database, :host, :param_authentication, :path, :realm, 
-        :expires_in,:logger)
+        :expires_in,:logger, :collection_prefix)
 
       # Global options. This is what we set during configuration (e.g. Rails'
       # config/application), and options all handlers inherit by default.
@@ -171,6 +172,7 @@ module Rack
         @options.authorize_path ||= "/oauth/authorize"
         @options.authorization_types ||=  %w{code token}
         @options.param_authentication ||= false
+        @options.collection_prefix ||= "oauth2"
       end
 
       # Options specific for this handle. @see Options

--- a/test/oauth/server_methods_test.rb
+++ b/test/oauth/server_methods_test.rb
@@ -15,6 +15,10 @@ class ServerTest < Test::Unit::TestCase
     should "set oauth.host" do
       assert_equal "example.org", Server.options.host
     end
+
+    should "set oauth.collection_prefix" do
+      assert_equal "oauth2_prefix", Server.options.collection_prefix
+    end
   end
 
   context "get_auth_request" do

--- a/test/rails2/config/environment.rb
+++ b/test/rails2/config/environment.rb
@@ -14,6 +14,7 @@ Rails::Initializer.run do |config|
   config.after_initialize do
     config.oauth.database = DATABASE
     config.oauth.host = "example.org"
+    config.oauth.collection_prefix = "oauth2_prefix"
     config.oauth.authenticator = lambda do |username, password|
       "Batman" if username == "cowbell" && password == "more"
     end

--- a/test/rails3/config/application.rb
+++ b/test/rails3/config/application.rb
@@ -8,6 +8,7 @@ module MyApp
     config.after_initialize do
       config.oauth.database = DATABASE
       config.oauth.host = "example.org"
+      config.oauth.collection_prefix = "oauth2_prefix"
       config.oauth.authenticator = lambda do |username, password|
         "Batman" if username == "cowbell" && password == "more"
       end

--- a/test/sinatra/my_app.rb
+++ b/test/sinatra/my_app.rb
@@ -11,8 +11,7 @@ class MyApp < Sinatra::Base
   end
   oauth.host = "example.org"
   oauth.database = DATABASE
-
-
+  oauth.collection_prefix = "oauth2_prefix"
 
   # 3.  Obtaining End-User Authorization
  


### PR DESCRIPTION
This is  small functionality  allows the user to set a prefix name for every mongo collection created by rack oauth server models.

In your initializer you will use it in the following way:

  config.after_initialize do
  ....
  config.oauth.collection_prefix = 'oauth_col_pre'
  ...
  end

For the oauth2-server binary you could pass --collection-prefix or -c.

If you don't set the parameter the prefix that is use by default is oauth2. 
