### PR TITLE
Delete oauth.no_scope from response headers to pass Rack::Lint check_headers test

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -226,7 +226,7 @@ module Rack
           # and return appropriate WWW-Authenticate header.
           response = @app.call(env)
           if response[0] == 403
-            scope = Utils.normalize_scope(response[1]["oauth.no_scope"])
+            scope = Utils.normalize_scope(response[1].delete("oauth.no_scope"))
             challenge = 'OAuth realm="%s", error="insufficient_scope", scope="%s"' % [(options.realm || request.host), scope.join(" ")]
             response[1]["WWW-Authenticate"] = challenge
             return response

--- a/test/oauth/access_token_test.rb
+++ b/test/oauth/access_token_test.rb
@@ -245,6 +245,9 @@ class AccessTokenTest < Test::Unit::TestCase
       should "respond with scope name" do
         assert_match " scope=\"math\"", last_response["WWW-Authenticate"]
       end
+      should "respond with proper headers" do
+        Rack::Lint.new(nil).check_headers(last_response.headers)
+      end
     end
   end
 


### PR DESCRIPTION
Lint checks that header keys only consist of letters, underscores, and dashes. oauth.no_scope in the response header was causing this test to fail.
