### PR TITLE
JRuby compatibility

### DIFF
--- a/rack-oauth2-server.gemspec
+++ b/rack-oauth2-server.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
   spec.add_dependency "rack", "~>1.1"
   spec.add_dependency "mongo", "~>1"
-  spec.add_dependency "bson_ext"
+  spec.add_dependency "bson_ext" if $platform.to_s == 'ruby'
   spec.add_dependency "sinatra", "~>1.1"
   spec.add_dependency "json"
   spec.add_dependency "jwt", "~>0.1.4"


### PR DESCRIPTION
The dependency on bson_ext mean that the gem won't install under JRuby.

Solved by only depending on bson_ext when the platform is ruby.
