### PR TITLE
Ruby-2: prevent fail on require iconv

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -3,7 +3,11 @@ require "rack/oauth2/models"
 require "rack/oauth2/server/errors"
 require "rack/oauth2/server/utils"
 require "rack/oauth2/server/helper"
-require "iconv"
+begin
+  require "iconv"
+rescue LoadError => e
+  puts e
+end
 require "json"
 
 module Rack


### PR DESCRIPTION
Iconv has been removed from Ruby 2.0.
I dont see any Iconv call on the code maybe we can remove it ?
