### PR TITLE
Prevents stack level too deep error

### DIFF
--- a/lib/rack/oauth2/models.rb
+++ b/lib/rack/oauth2/models.rb
@@ -40,7 +40,7 @@ module Rack
         def database
           @database ||= Server.options.database
           raise "No database Configured. You must configure it using Server.options.database = Mongo::Connection.new()[db_name]" unless @database
-          raise "You set Server.database to #{Server.database.class}, should be a Mongo::DB object" unless Mongo::DB === @database
+          raise "You set Server.database to #{@database.class}, should be a Mongo::DB object" unless Mongo::DB === @database
           @database
         end
       end


### PR DESCRIPTION
If a database option was incorrectly set the error handling was causing a `stack level too deep` exception.
