### PR TITLE
Includes a content-type for unauthorized requests

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -500,7 +500,7 @@ module Rack
       def unauthorized(request, error = nil)
         challenge = 'OAuth realm="%s"' % (options.realm || request.host)
         challenge << ', error="%s", error_description="%s"' % [error.code, error.message] if error
-        return [401, { "WWW-Authenticate"=>challenge }, [error && error.message || ""]]
+        return [401, { "WWW-Authenticate"=>challenge, "Content-Type"=>"application/json" }, [error && error.message || ""]]
       end
 
       # Processes a JWT assertion


### PR DESCRIPTION
Rack::Lint will complain about a 401 return that doesn't include a content type
